### PR TITLE
Fixed get_user when id is not numeric

### DIFF
--- a/party/user.py
+++ b/party/user.py
@@ -46,19 +46,25 @@ class User:
         resp = requests.get(f"{base_url}/api/creators")
         return UserSchema(context=dict(site=base_url)).loads(resp.text, many=True)
 
-    @classmethod
-    def get_user(cls, base_url: str, service: str, search: str):
-        """Return a User object from a match against service and search.
+@classmethod
+def get_user(cls, base_url: str, service: str, search: str):
+    """Return a User object from a match against service and search.
 
-        Args:
-            base_url: kemono.party or coomer.party
-            service: { kemono: [patreon, fanbox, fantia, etc...], coomer: [onlyfans]}
-            search: user id or user name
-        Returns:
-            User
-        """
-        users = cls.generate_users(base_url)
-        attr = "id" if search.isnumeric() else "name"
+    Args:
+        base_url: kemono.party or coomer.party
+        service: { kemono: [patreon, fanbox, fantia, etc...], coomer: [onlyfans]}
+        search: user id or user name
+    Returns:
+        User
+    """
+    users = cls.generate_users(base_url)
+    try:
+        attr = "id"
+        return next(
+            (i for i in users if i.service == service and getattr(i, attr) == search)
+        )
+    except StopIteration:
+        attr = "name"
         return next(
             (i for i in users if i.service == service and getattr(i, attr) == search)
         )

--- a/party/user.py
+++ b/party/user.py
@@ -49,7 +49,7 @@ class User:
     @classmethod
     def get_user(cls, base_url: str, service: str, search: str):
         """Return a User object from a match against service and search.
-    
+
         Args:
             base_url: kemono.party or coomer.party
             service: { kemono: [patreon, fanbox, fantia, etc...], coomer: [onlyfans]}

--- a/party/user.py
+++ b/party/user.py
@@ -46,28 +46,28 @@ class User:
         resp = requests.get(f"{base_url}/api/creators")
         return UserSchema(context=dict(site=base_url)).loads(resp.text, many=True)
 
-@classmethod
-def get_user(cls, base_url: str, service: str, search: str):
-    """Return a User object from a match against service and search.
-
-    Args:
-        base_url: kemono.party or coomer.party
-        service: { kemono: [patreon, fanbox, fantia, etc...], coomer: [onlyfans]}
-        search: user id or user name
-    Returns:
-        User
-    """
-    users = cls.generate_users(base_url)
-    try:
-        attr = "id"
-        return next(
-            (i for i in users if i.service == service and getattr(i, attr) == search)
-        )
-    except StopIteration:
-        attr = "name"
-        return next(
-            (i for i in users if i.service == service and getattr(i, attr) == search)
-        )
+    @classmethod
+    def get_user(cls, base_url: str, service: str, search: str):
+        """Return a User object from a match against service and search.
+    
+        Args:
+            base_url: kemono.party or coomer.party
+            service: { kemono: [patreon, fanbox, fantia, etc...], coomer: [onlyfans]}
+            search: user id or user name
+        Returns:
+            User
+        """
+        users = cls.generate_users(base_url)
+        try:
+            attr = "id"
+            return next(
+                (i for i in users if i.service == service and getattr(i, attr) == search)
+            )
+        except StopIteration:
+            attr = "name"
+            return next(
+                (i for i in users if i.service == service and getattr(i, attr) == search)
+            )
 
     def generate_posts(self, raw: bool = False) -> Iterator[Post]:
         """Generator for Posts from this user


### PR DESCRIPTION
Implemented my solution in #5. I'm not too familiar with github hence why I haven't done this sooner. 
This fixes services on kemono like subscribestar while still being able to do the command in the standard format e.g. `party kemono subscribestar skylardoodles` if you were to attempt to download [skylardoodles](https://kemono.party/subscribestar/user/skylardoodles) from kemono.party / kemono.su.