### PR TITLE
some updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
     </li>
     <li><a href="#usage">Usage</a></li>
       <ul>
-        <li><a href="#Download">Download from Kemono and Coomer</a></li>
-        <li><a href="#Update">Update</a></li>
-        <li><a href="#Search">Search</a></li>
+        <li><a href="#download">Download from Kemono and Coomer</a></li>
+        <li><a href="#update">Update</a></li>
+        <li><a href="#search">Search</a></li>
       </ul>
     <li><a href="#roadmap">Roadmap</a></li>
   </ol>

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ You can either clone the repo or install from Releases.
         <service>: Ex. patreon, fantia, onlyfans
         <creator>: username or id of the user
 
-        -l --limit INTEGER				Number of posts to parse, from newest to oldest.
+        -l --limit INTEGER			Number of posts to parse, from newest to oldest.
         -e --exclude-extension TEXT		Don't download files with extenstion TEXT. Can be given multiple times.
-        -w --workers INTEGER			Number of concurrent downloads.
-        --name TEXT						Skip user db pull/search.
+        -w --workers INTEGER		Number of concurrent downloads.
+        --name TEXT				Skip user db pull/search.
         -d, --directory TEXT    		Specify an output directory.
 
 Examples

--- a/README.md
+++ b/README.md
@@ -17,18 +17,20 @@
   <ol>
     <li>
       <a href="#about-the-project">About The Project</a>
-      <ul>
-        <li><a href="#built-with">Built With</a></li>
-      </ul>
     </li>
     <li>
       <a href="#getting-started">Getting Started</a>
       <ul>
         <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation">I nstallation</a></li>
+        <li><a href="#installation">Installation</a></li>
       </ul>
     </li>
     <li><a href="#usage">Usage</a></li>
+      <ul>
+        <li><a href="#Download">Download from Kemono and Coomer</a></li>
+        <li><a href="#Update">Update</a></li>
+        <li><a href="#Search">Search</a></li>
+      </ul>
     <li><a href="#roadmap">Roadmap</a></li>
   </ol>
 </details>
@@ -105,7 +107,8 @@ You can either clone the repo or install from Releases.
   search: Find creators based on username or id
   ```
   
-**Kemono and Coomer**
+### Download
+***Kemono and Coomer***
 
   A basic breakdown of the options
   > party \<site> \<service> \<creator> [options]
@@ -139,7 +142,7 @@ Examples
 
 Party will check for existing files while downloading, so incomplete archives can be completed with kemono/coomer or with update. 
 
-**Update**
+### Update
 
 - Update an existing directory
   ```sh
@@ -148,7 +151,7 @@ Party will check for existing files while downloading, so incomplete archives ca
   - This will skip creator list download, since we have that data.
   - If the creator was initially downloaded with extensions excluded (option -e), update will retain those exclusions.
 
-**Search**
+### Search
 
 Search supports all options kemono and coomer take, e.g. -e, -w, -d, -l
 

--- a/README.md
+++ b/README.md
@@ -94,39 +94,63 @@ You can either clone the repo or install from Releases.
 
 <!-- USAGE EXAMPLES -->
 ## Usage
+  Party has 4 basic commands
+
+ > party \<command>
+
+ ```sh
+  kemono: Download from kemono
+  coomer: Download from coomer
+  update: Checks for and downloads new posts
+  search: Find creators based on username or id
+  ```
+  
+**Kemono and Coomer**
+
+  A basic breakdown of the options
+  > party \<site> \<service> \<creator> [options]
+
+        <site>: Kemono or Coomer
+        <service>: Ex. patreon, fantia, onlyfans
+        <creator>: username or id of the user
+
+        -l --limit INTEGER				Number of posts to parse, from newest to oldest.
+        -e --exclude-extension TEXT		Don't download files with extenstion TEXT. Can be given multiple times.
+        -w --workers INTEGER			Number of concurrent downloads.
+        --name TEXT						Skip user db pull/search.
+        -d, --directory TEXT    		Specify an output directory.
+
+Examples
 
 - Download something from kemono
   ```sh
   party kemono patreon diives
   ```
 
-  A basic breakdown of the options
-  > party kemono \<service> \<creator> [options]
-
-        service: Ex. patreon, fantia, onlyfans
-        user_id: either name or id of the user
-        base_url: Swapable for coomer.party
-        files: add post['file'] to downloads
-        exclude_external: filter out files not hosted on *.party
-        limit: limit the number of posts we pull from
-        ignore_extensions: drop files with these extensions
-        workers: number of open connections allowed
-        name: skip downloading the user db, generate user with name, service, user_id
-
 - Download something from coomer
   ```sh
-  # party coomer <service> <creator> [options] // only service used to be onlyfans, but now fansly is supported
   party coomer onlyfans belledelphine
-
-  # Second example for fansly
-  party coomer fansly forgottenlovechild
   ```
+
+- Download from coomer, exclude pictures, and limit to 2 downloads
+  ```sh
+  party coomer fansly forgottenlovechild -e jpg -e jpeg -e png -w 2
+  ```
+
+Party will check for existing files while downloading, so incomplete archives can be completed with kemono/coomer or with update. 
+
+**Update**
 
 - Update an existing directory
   ```sh
-  # Note: This will skip creator list download, since we have that data
   party update diives
   ```
+  - This will skip creator list download, since we have that data.
+  - If the creator was initially downloaded with extensions excluded (option -e), update will retain those exclusions.
+
+**Search**
+
+Search supports all options kemono and coomer take, e.g. -e, -w, -d, -l
 
 - Search for a user
   ```sh
@@ -135,7 +159,7 @@ You can either clone the repo or install from Releases.
 
 - Search for a user and select results interactively
   ```sh
-  party search belk -i  
+  party search belk -i
   +-------+------------------+--------------------+---------+
   | Index |       Name       |         ID         | Service |
   +-------+------------------+--------------------+---------+
@@ -152,7 +176,7 @@ You can either clone the repo or install from Releases.
 
 - A more specific search
   ```sh
-  party search --site coomer --service fansly forgotten
+  party search --site coomer --service fansly forgotten -w 3 -e jpg
   +-------+--------------------+--------------------+---------+
   | Index |        Name        |         ID         | Service |
   +-------+--------------------+--------------------+---------+

--- a/party/cli.py
+++ b/party/cli.py
@@ -25,52 +25,19 @@ from .user import User
 
 APP = typer.Typer(no_args_is_help=True)
 
-
-@APP.command(name="kemono", no_args_is_help=True)
 def pull_user(
-    service: Annotated[
-        str,
-        typer.Argument(
-            help="Specify the service to pull from; Ex(patreon,fanbox,onlyfans)"
-        ),
-    ],
-    user_id: Annotated[
-        str, typer.Argument(help="User id from the url or name from search")
-    ],
-    base_url: Annotated[
-        str,
-        typer.Option(
-            help="Base for the site. Default is kemono.party but you can set it to https://coomer.party",
-        ),
-    ] = "https://kemono.party",
+    service: str,
+    user_id: str, 
+    base_url: str,
     files: bool = True,
     exclude_external: bool = True,
-    limit: Annotated[
-        int,
-        typer.Option(
-            "-l",
-            "--limit",
-            help="Number of posts to parse. Starts from newest to oldest.",
-        ),
-    ] = None,
+    limit: int = None,
     post_id: bool = None,
-    ignore_extensions: list[str] = typer.Option(
-        [], "-i", "--ignore-extensions", help="File extensions to ignore"
-    ),
-    workers: int = typer.Option(
-        4, "-w", "--workers", help="Number of open download connections"
-    ),
-    name: Annotated[
-        str,
-        typer.Option(
-            help="If you provided an id in the argument, you can provide a name here to skip user db pull/search",
-        ),
-    ] = None,
-    directory: Annotated[
-        str, typer.Option("-d", "--directory", help="Specify an output directory")
-    ] = None,
+    ignore_extensions: list[str] = [], 
+    workers: int = 4,
+    name: str = None,
+    directory: str = None
 ):
-    """Quick download command for kemono.party"""
     logger.debug(f"Ignored Extensions: {ignore_extensions}")
     if name:
         user = User(user_id, name, service, site=base_url)
@@ -179,21 +146,57 @@ async def download_async(pbar, base_url, directory, files, workers: int = 10):
         downloads = [download(f) for f in files]
         return await asyncio.gather(*downloads)
 
-
 @APP.command()
-def onlyfans(
-    user_id: str,
+def kemono(
+    service: Annotated[
+        str, typer.Argument(
+            help="Specify the service to pull from; Ex(patreon,fanbox,onlyfans)"
+        )
+    ],
+    user_id: Annotated[
+        str, typer.Argument(
+            help="User id from the url or name from search"
+        )
+    ],
     files: bool = True,
-    limit: int = None,
-    ignore_extensions: list[str] = typer.Option(None, "-i"),
-    post_id: bool = False,
-    workers: int = typer.Option(10, "-w"),
-    name: str = None,
-    directory: Annotated[str, typer.Option(help="Specify an output directory")] = None,
+    limit: Annotated[
+        int, typer.Option(
+            "-l",
+            "--limit",
+            help="Number of posts to parse. Starts from newest to oldest."
+        )
+    ] = None,
+    post_id: bool = None,
+    ignore_extensions: Annotated[
+        list[str], typer.Option(
+            "-i",
+            "--ignore-extensions", 
+            help="File extensions to ignore"
+        )
+    ] = [],
+    workers: Annotated[
+        int, typer.Option( 
+            "-w", 
+            "--workers", 
+            help="Number of open download connections"
+        )
+    ] = 4,
+    name: Annotated[
+        str, typer.Option(
+            "--name",
+            help="If you provided an id in the argument, you can provide a name here to skip user db pull/search"
+        ),
+    ] = None,
+    directory: Annotated[
+        str, typer.Option(
+            "-d",
+            "--directory", 
+            help="Specify an output directory"
+        )
+    ] = None
 ):
-    """Convenience command for running against coomer, Onlyfans"""
-    base = "https://coomer.party"
-    service = "onlyfans"
+    """Quick download command for kemono.party"""
+    base = "https://kemono.party"
     pull_user(
         service,
         user_id,
@@ -207,24 +210,57 @@ def onlyfans(
         directory=directory,
     )
 
-
 @APP.command()
 def coomer(
-    service: str,
-    user_id: str,
+    service: Annotated[
+        str, typer.Argument(
+            help="Specify the service to pull from; Ex(patreon,fanbox,onlyfans)"
+        )
+    ],
+    user_id: Annotated[
+        str, typer.Argument(
+            help="User id from the url or name from search"
+        )
+    ],
     files: bool = True,
-    limit: int = None,
-    ignore_extensions: list[str] = typer.Option(None, "-i"),
-    post_id: bool = False,
-    workers: int = typer.Option(2, "-w"),
-    name: str = None,
-    directory: Annotated[
-        str, typer.Option("-d", "--directory", help="Specify an output directory")
+    limit: Annotated[
+        int, typer.Option(
+            "-l",
+            "--limit",
+            help="Number of posts to parse. Starts from newest to oldest."
+        )
     ] = None,
+    post_id: bool = None,
+    ignore_extensions: Annotated[
+        list[str], typer.Option(
+            "-i",
+            "--ignore-extensions", 
+            help="File extensions to ignore"
+        )
+    ] = [],
+    workers: Annotated[
+        int, typer.Option( 
+            "-w", 
+            "--workers", 
+            help="Number of open download connections"
+        )
+    ] = 4,
+    name: Annotated[
+        str, typer.Option(
+            "--name",
+            help="If you provided an id in the argument, you can provide a name here to skip user db pull/search"
+        ),
+    ] = None,
+    directory: Annotated[
+        str, typer.Option(
+            "-d",
+            "--directory", 
+            help="Specify an output directory"
+        )
+    ] = None
 ):
     """Convenience command for running against coomer, services[fansly,onlyfans]"""
     base = "https://coomer.party"
-    # service = "onlyfans"
     pull_user(
         service,
         user_id,
@@ -241,18 +277,46 @@ def coomer(
 
 @APP.command(no_args_is_help=True)
 def search(
-    search_str: str,
-    site: str = None,
-    service: str = None,
-    ignore_extensions: list[str] = typer.Option(None, "-i"),
-    interactive: bool = typer.Option(False, "-i", "--interactive"),
+    search_str: Annotated[
+        str, typer.Argument(
+            help="Search string to match against usernames"
+        )
+    ]=None,
+    site: Annotated[
+        str, typer.Option(
+            "--site", 
+            help="Specify the site to pull from; default to kemono."
+        )
+    ]=None,
+    service: Annotated[
+        str, typer.Option(
+            "--service", 
+            help="Specify service (e.g. pixiv, onlyfans, fansly, etc)."
+    )
+    ]=None,
+    ignore_extensions: Annotated[
+        list[str], typer.Option(
+            "-i",
+            "--ignore-extensions", 
+            help="File extensions to ignore"
+        )
+    ] = [],
+    interactive: Annotated[
+        bool, typer.Option(
+            "-I",
+            "--interactive", 
+            help = "Prompt for selection from results."
+        )
+    ]=False,
+    workers: Annotated[
+        int, typer.Option( 
+            "-w", 
+            "--workers", 
+            help="Number of open download connections"
+        )
+    ] = 4
 ):
-    """Search function
-    Args:
-        search_str: used to filter users against name.lower()
-        site: default to kemono, if string 'coomer' user the coomer url
-        service: service name to filter users against [patreon,fantia,fanbox,etc...]
-    """
+    """Search function """
     base_url = "https://kemono.party"
     if site == "coomer":
         base_url = "https://coomer.party"
@@ -272,7 +336,7 @@ def search(
         selection = typer.prompt("Index selection: ", type=int)
         user = results[selection]
         typer.secho(
-            f"Downloading {user.name} using default options...",
+            f"Downloading {user.name} with specified options...",
             fg=typer.colors.BRIGHT_GREEN,
         )
         pull_user(
@@ -280,7 +344,7 @@ def search(
             user.id,
             name=user.name,
             base_url=base_url,
-            workers=8,
+            workers=workers,
             ignore_extensions=ignore_extensions,
         )
 

--- a/party/cli.py
+++ b/party/cli.py
@@ -25,53 +25,59 @@ from .user import User
 
 APP = typer.Typer(no_args_is_help=True)
 
+# Define Common args and options for commands 
 
-@APP.command(name="kemono", no_args_is_help=True)
+service_arg = typer.Argument(
+    help="Specify the service to pull from; Ex(patreon,fanbox,onlyfans)"
+)
+
+userid_arg = typer.Argument(
+    help="User id from the url or name from search"
+)
+
+limit_option = typer.Option(
+    "-l",
+    "--limit",
+    help="Number of posts to parse. Starts from newest to oldest.",
+)
+
+extension_option = typer.Option(
+    "-e",
+    "--exclude-extension",
+    help="File extension to exclude"
+)
+
+worker_option = typer.Option(
+    "-w",
+    "--workers",
+    help="Number of open download connections"
+)
+
+name_option = typer.Option(
+    help= "If you provided an id in the argument, you can provide a name here" +
+    " to skip user db pull/search."
+)
+
+dir_option = typer.Option(
+    "-d",
+    "--directory",
+    help="Specify an output directory"
+)
+
 def pull_user(
-    service: Annotated[
-        str,
-        typer.Argument(
-            help="Specify the service to pull from; Ex(patreon,fanbox,onlyfans)"
-        ),
-    ],
-    user_id: Annotated[
-        str, typer.Argument(help="User id from the url or name from search")
-    ],
-    base_url: Annotated[
-        str,
-        typer.Option(
-            help="Base for the site. Default is kemono.party but you can set it to https://coomer.party",
-        ),
-    ] = "https://kemono.party",
-    files: bool = True,
-    exclude_external: bool = True,
-    limit: Annotated[
-        int,
-        typer.Option(
-            "-l",
-            "--limit",
-            help="Number of posts to parse. Starts from newest to oldest.",
-        ),
-    ] = None,
-    post_id: bool = None,
-    ignore_extensions: list[str] = typer.Option(
-        [], "-i", "--ignore-extensions", help="File extensions to ignore"
-    ),
-    workers: int = typer.Option(
-        4, "-w", "--workers", help="Number of open download connections"
-    ),
-    name: Annotated[
-        str,
-        typer.Option(
-            help="If you provided an id in the argument, you can provide a name here to skip user db pull/search",
-        ),
-    ] = None,
-    directory: Annotated[
-        str, typer.Option("-d", "--directory", help="Specify an output directory")
-    ] = None,
+    service: str, 
+    user_id: str,
+    base_url: str, 
+    files: bool,
+    exclude_external: bool,
+    limit: int, 
+    post_id: bool,
+    exclude_extensions: list[str], 
+    workers: int,
+    name: str,
+    directory: str 
 ):
-    """Quick download command for kemono.party"""
-    logger.debug(f"Ignored Extensions: {ignore_extensions}")
+    logger.debug(f"Excluded Extensions: {exclude_extensions}")
     if name:
         user = User(user_id, name, service, site=base_url)
     else:
@@ -88,7 +94,7 @@ def pull_user(
     if not os.path.exists(directory):
         os.mkdir(directory)
     options = dict(
-        ignore_extensions=ignore_extensions,
+        exclude_extensions=exclude_extensions,
         files=files,
         exclude_external=exclude_external,
         base_url=base_url,
@@ -99,10 +105,9 @@ def pull_user(
         posts = list(user.limit_posts(limit))
         embedded = [embed for p in user.posts if (embed := p.embed)]
         files = [f for p in posts for f in p.get_files(files)]
-        if ignore_extensions:
-            filter_ = lambda x: not any(
-                x["name"].endswith(i) for i in ignore_extensions
-            )
+        if exclude_extensions:
+            filter_ = lambda x: not any(x["name"].endswith(i)
+                                        for i in exclude_extensions)
             files = list(filter(filter_, files))
         if post_id is None:
             fn_set = {i.name for i in files}
@@ -132,13 +137,15 @@ def pull_user(
             f"Embedded objects found; saving to {embed_filename}",
             fg=typer.colors.BRIGHT_MAGENTA,
         )
-        with open(f"{directory}/.embedded", "w", encoding="utf-8") as embed_file:
+        with open(f"{directory}/.embedded", "w",
+                  encoding="utf-8") as embed_file:
             json.dump(embedded, embed_file)
     with open(f"{directory}/.posts", "w", encoding="utf-8") as posts_file:
         json.dump(posts, posts_file, for_json=True)
     typer.secho(f"Downloading from user: {user.name}", fg=typer.colors.MAGENTA)
     with tqdm(total=len(files)) as pbar:
-        output = asyncio.run(download_async(pbar, base_url, directory, files, workers))
+        output = asyncio.run(
+            download_async(pbar, base_url, directory, files, workers))
     count = Counter(output)
     logger.info(f"Output status: {count}")
 
@@ -150,19 +157,23 @@ async def download_async(pbar, base_url, directory, files, workers: int = 10):
 
     token = generate_token()
     async with aiohttp.ClientSession(
-        base_url,
-        timeout=timeout,
-        headers={
-            "Accept-Encoding": "gzip, deflate, br",
-            "Cache-Control": "no-cache",
-            "pragma": "no-cache",
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 "
-            "Safari/537.36",
-        },
-        cookies={"__ddg2": token},
-        # cookies={"__ddg1_":"qizlDnO45jI7QjIcwCXk"},
-        connector=conn,
+            base_url,
+            timeout=timeout,
+            headers={
+                "Accept-Encoding":
+                "gzip, deflate, br",
+                "Cache-Control":
+                "no-cache",
+                "pragma":
+                "no-cache",
+                "User-Agent":
+                "Mozilla/5.0 (X11; Linux x86_64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 "
+                "Safari/537.36",
+            },
+            cookies={"__ddg2": token},
+    # cookies={"__ddg1_":"qizlDnO45jI7QjIcwCXk"},
+            connector=conn,
     ) as session:
         semaphore = asyncio.Semaphore(workers)
 
@@ -179,32 +190,60 @@ async def download_async(pbar, base_url, directory, files, workers: int = 10):
         downloads = [download(f) for f in files]
         return await asyncio.gather(*downloads)
 
-
 @APP.command()
-def coomer(
-    service: str,
-    user_id: str,
+def kemono(
+    service: Annotated[str, service_arg],
+    user_id: Annotated[str, userid_arg],
     files: bool = True,
-    limit: int = None,
-    ignore_extensions: list[str] = typer.Option(None, "-i"),
-    post_id: bool = False,
-    workers: int = typer.Option(2, "-w"),
-    name: str = None,
-    directory: Annotated[
-        str, typer.Option("-d", "--directory", help="Specify an output directory")
-    ] = None,
+    exclude_external: bool = True,
+    limit: Annotated[int, limit_option] = None,
+    post_id: bool = None,
+    exclude_extensions: Annotated[list[str], extension_option] = [],
+    workers: Annotated[int, worker_option] = 4,
+    name: Annotated[str, name_option ] = None, 
+    directory: Annotated[str, dir_option] = None
 ):
-    """Convenience command for running against coomer, services[fansly,onlyfans]"""
-    base = "https://coomer.party"
-    # service = "onlyfans"
+
+    """Quick download command for kemono.party"""
+    base = "https://kemono.party"
     pull_user(
         service,
         user_id,
         base,
         files=files,
+        exclude_external=exclude_external,
         limit=limit,
         post_id=post_id,
-        ignore_extensions=ignore_extensions,
+        exclude_extensions=exclude_extensions,
+        workers=workers,
+        name=name,
+        directory=directory,
+    )
+
+@APP.command()
+def coomer(
+    service: Annotated[str, service_arg],
+    user_id: Annotated[str, userid_arg],
+    files: bool = True,
+    exclude_external: bool = True,
+    limit: Annotated[int, limit_option] = None,
+    post_id: bool = None,
+    exclude_extensions: Annotated[list[str], extension_option] = [],
+    workers: Annotated[int, worker_option] = 4,
+    name: Annotated[str, name_option ] = None, 
+    directory: Annotated[str, dir_option] = None
+):
+    """Convenience command for running against coomer, services[fansly,onlyfans]"""
+    base = "https://coomer.party"
+    pull_user(
+        service,
+        user_id,
+        base,
+        files=files,
+        exclude_external=exclude_external,
+        limit=limit,
+        post_id=post_id,
+        exclude_extensions=exclude_extensions,
         workers=workers,
         name=name,
         directory=directory,
@@ -213,27 +252,39 @@ def coomer(
 
 @APP.command(no_args_is_help=True)
 def search(
-    search_str: str,
-    site: str = None,
-    service: str = None,
-    ignore_extensions: list[str] = typer.Option(None, "-i"),
-    interactive: bool = typer.Option(False, "-i", "--interactive"),
+        search_str: Annotated[
+            str,
+            typer.Argument(help="used to filter users against name.lower()")
+        ],
+        site: Annotated[
+            str,
+            typer.Argument(help="kemono or coomer")
+        ],
+        service: Annotated[
+            str, 
+            typer.Option(
+                "--service",
+                help="service name to filter users against [patreon,fantia,fanbox,etc...]"
+            )
+        ] = None,
+        exclude_external: bool = True,
+        limit: Annotated[int, limit_option] = None,
+        exclude_extensions: Annotated[list[str], extension_option] = [],
+        interactive: bool = typer.Option(False, "-i", "--interactive"),
+        workers: Annotated[int, worker_option] = 4,
+        directory: Annotated[str, dir_option] = None
 ):
-    """Search function
-    Args:
-        search_str: used to filter users against name.lower()
-        site: default to kemono, if string 'coomer' user the coomer url
-        service: service name to filter users against [patreon,fantia,fanbox,etc...]
-    """
-    base_url = "https://kemono.party"
-    if site == "coomer":
+    """Search function"""
+    if site == "kemono":
+        base_url = "https://kemono.party"
+    elif site == "coomer":
         base_url = "https://coomer.party"
+    else:
+        logger.info(f"Invalid site: {site}. Use 'kemono' or 'coomer'.")
+        return 
     users = User.generate_users(base_url)
-    check = (
-        (lambda x: x.service == service and search_str in x.name.lower())
-        if service
-        else (lambda x: search_str in x.name.lower())
-    )
+    check = ((lambda x: x.service == service and search_str in x.name.lower())
+             if service else (lambda x: search_str in x.name.lower()))
     results = [i for i in users if check(i)]
     table = PrettyTable()
     table.field_names = ["Index", "Name", "ID", "Service"]
@@ -244,24 +295,28 @@ def search(
         selection = typer.prompt("Index selection: ", type=int)
         user = results[selection]
         typer.secho(
-            f"Downloading {user.name} using default options...",
+            f"Downloading {user.name} using specified options...",
             fg=typer.colors.BRIGHT_GREEN,
         )
         pull_user(
-            user.service,
+            user.service, 
             user.id,
+            base_url, 
+            files=True,
+            exclude_external=exclude_external,
+            limit=limit,
+            post_id=True,
+            exclude_extensions=exclude_extensions,
+            workers=workers,
             name=user.name,
-            base_url=base_url,
-            workers=8,
-            ignore_extensions=ignore_extensions,
+            directory=directory
         )
-
 
 @APP.command()
 def custom_parse(
     service: str,
     user_id: str,
-    search: str,  # pylint: disable=redefined-outer-name
+    search: str,    # pylint: disable=redefined-outer-name
     limit: int = None,
 ):
     """Uses provided regex to pull links from the content key on posts"""
@@ -275,15 +330,22 @@ def custom_parse(
 
 
 @APP.command()
-def update(folder: str, limit: int = None):
+def update(
+        folder: str,
+        limit: Annotated[int, limit_option] = None,
+        workers: Annotated[int, worker_option] = 4,
+):
     """Update an existing pull from a party site"""
     with open(f"{folder}/.info", encoding="utf-8") as info:
         settings = json.load(info)
+    # make backwards compatible with old option "--ignore-extensions"
+    if "ignore_extensions" in settings["options"]:
+        settings["options"]["exclude_extensions"] = settings["options"].pop("ignore_extensions")
     pull_user(
         settings["user"]["service"],
         settings["user"]["id"],
         name=settings["user"]["name"],
-        workers=4,
+        workers=workers,
         limit=limit,
         **settings["options"],
     )
@@ -291,10 +353,10 @@ def update(folder: str, limit: int = None):
 
 @APP.command()
 def details(
-    service: str,
-    user_id: str,
-    base_url: str = "https://kemono.party",
-    ignore_extensions: list[str] = typer.Option(None, "-i"),
+        service: str,
+        user_id: str,
+        base_url: str = "https://kemono.party",
+        exclude_extensions: list[str] = typer.Option(None, "-i"),
 ):
     """Show user details: (post#,attachment#,files#)"""
 
@@ -305,12 +367,14 @@ def details(
         posts = user.posts
         attachments = [a for p in posts for a in p.attachments]
         files = [p.file for p in posts if p.file]
-        if ignore_extensions:
-            filter_ = lambda x: not any(x.name.endswith(i) for i in ignore_extensions)
+        if exclude_extensions:
+            filter_ = lambda x: not any(
+                x.name.endswith(i) for i in exclude_extensions)
             attachments = list(filter(filter_, attachments))
             files = list(filter(filter_, files))
         spin.ok("✔")
-    logger.info(dict(posts=len(posts), attachments=len(attachments), files=len(files)))
+    logger.info(
+        dict(posts=len(posts), attachments=len(attachments), files=len(files)))
 
 
 @APP.command()
@@ -330,13 +394,15 @@ def embedded_links(
 
 
 @APP.callback()
-def configure(verbose: bool = False):
+def configure(
+    verbose: bool = False,
+):
     """A quick cli for downloading from party-chan sites"""
+
     if verbose:
         return
     logger.remove()
     logger.add(sys.stderr, level="DEBUG")
-
 
 if __name__ == "__main__":
     APP()

--- a/party/cli.py
+++ b/party/cli.py
@@ -181,34 +181,6 @@ async def download_async(pbar, base_url, directory, files, workers: int = 10):
 
 
 @APP.command()
-def onlyfans(
-    user_id: str,
-    files: bool = True,
-    limit: int = None,
-    ignore_extensions: list[str] = typer.Option(None, "-i"),
-    post_id: bool = False,
-    workers: int = typer.Option(10, "-w"),
-    name: str = None,
-    directory: Annotated[str, typer.Option(help="Specify an output directory")] = None,
-):
-    """Convenience command for running against coomer, Onlyfans"""
-    base = "https://coomer.party"
-    service = "onlyfans"
-    pull_user(
-        service,
-        user_id,
-        base,
-        files=files,
-        limit=limit,
-        post_id=post_id,
-        ignore_extensions=ignore_extensions,
-        workers=workers,
-        name=name,
-        directory=directory,
-    )
-
-
-@APP.command()
 def coomer(
     service: str,
     user_id: str,

--- a/party/posts.py
+++ b/party/posts.py
@@ -103,10 +103,10 @@ class Attachment:
                         fbar.close()
                         status = StatusEnum.ERROR_OSERROR
                 else:
-                    logger.debug(
-                        dict(status=resp.status, filename=filename,
-                            url=resp.url, headers=resp.headers)
-                    )
+                    #logger.debug(
+                    #    dict(status=resp.status, filename=filename,
+                    #        url=resp.url, headers=resp.headers)
+                    #)
                     status = StatusEnum.ERROR_429
         except aiohttp.client_exceptions.TooManyRedirects as err:
             logger.debug(dict(error=err, filename=filename, url=self.path))


### PR DESCRIPTION
- cleaned up cli.py options. Less duplicated code, and options are now uniform across coomer, kemono, search, etc
- changed --ignore.. to --exclude.. to not conflict with --interactive on search.
- help text for each command is now complete and uniform.
- added some error handling for 429 errors. 
- Keeps track of files returning 429 errors, each 429 error reduces number of current workers until only one remains. 
- Loops the downloads until there are no more files to download, decreasing initial number of workers each loop.
- pbar doesn't increment on 429 errors
- This is a hacky fix, probably needs to be changed to not use a semaphore?  